### PR TITLE
Add states

### DIFF
--- a/sciolyid/__init__.py
+++ b/sciolyid/__init__.py
@@ -64,6 +64,7 @@ def setup(*args, **kwargs):
         "list_dir",
         "log_dir",
         "restricted_list_dir",
+        "state_dir",
         "tmp_upload_dir",
         "validation_local_dir",
         "validation_repo_dir",
@@ -89,6 +90,7 @@ def setup(*args, **kwargs):
         "list_dir",
         "meme_file",
         "restricted_list_dir",
+        "state_dir",
         "wikipedia_file",
     )
     for item in data_subdirs:

--- a/sciolyid/__init__.py
+++ b/sciolyid/__init__.py
@@ -61,9 +61,8 @@ def setup(*args, **kwargs):
         "bot_files_dir",
         "data_dir",
         "download_dir",
-        "list_dir",
+        "group_dir",
         "log_dir",
-        "restricted_list_dir",
         "state_dir",
         "tmp_upload_dir",
         "validation_local_dir",
@@ -87,9 +86,8 @@ def setup(*args, **kwargs):
             ] = f"{config.options['bot_files_dir']}{config.options[item]}"
 
     data_subdirs = (
-        "list_dir",
+        "group_dir",
         "meme_file",
-        "restricted_list_dir",
         "state_dir",
         "wikipedia_file",
     )

--- a/sciolyid/cogs/check.py
+++ b/sciolyid/cogs/check.py
@@ -111,12 +111,12 @@ class Check(commands.Cog):
                         await race.stop_race(ctx)
                     else:
                         logger.info("auto sending next image")
-                        group, bw = database.hmget(
-                            f"race.data:{ctx.channel.id}", ["group", "bw"]
+                        group, state, bw = database.hmget(
+                            f"race.data:{ctx.channel.id}", ["group", "state", "bw"]
                         )
                         media = self.bot.get_cog("Media")
                         await media.send_pic(
-                            ctx, group.decode("utf-8"), bw.decode("utf-8")
+                            ctx, group.decode("utf-8"), state.decode("utf-8"), bw.decode("utf-8")
                         )
 
             else:

--- a/sciolyid/cogs/media.py
+++ b/sciolyid/cogs/media.py
@@ -160,8 +160,6 @@ class Media(commands.Cog):
                 else:
                     await ctx.send(f"**Invalid argument provided**: `{arg}`")
                     return
-            group = " ".join(group_args).strip()
-            state = " ".join(state_args).strip()
 
             if database.exists(f"session.data:{ctx.author.id}"):
                 logger.info("session parameters")

--- a/sciolyid/cogs/media.py
+++ b/sciolyid/cogs/media.py
@@ -16,22 +16,23 @@
 
 import random
 import string
-
-from discord.ext import commands
+from typing import Union
 
 import sciolyid.config as config
+from discord.ext import commands
 from sciolyid.core import send_image
 from sciolyid.data import (
     GenericError,
     all_categories,
     database,
     dealias_group,
-    id_list,
     logger,
+    states,
 )
 from sciolyid.functions import (
     CustomCooldown,
     build_id_list,
+    check_state_role,
     item_setup,
     session_increment,
 )
@@ -54,7 +55,7 @@ class Media(commands.Cog):
         async def inner(error):
             nonlocal retries
 
-            # skip current bird
+            # skip current item
             database.hset(f"channel:{ctx.channel.id}", "item", "")
             database.hset(f"channel:{ctx.channel.id}", "answered", "1")
 
@@ -76,7 +77,11 @@ class Media(commands.Cog):
         item_setup(ctx, item)
         database.zincrby("frequency.item:global", 1, string.capwords(item))
 
-    async def send_pic(self, ctx, group_str: str, bw: bool = False, retries=0):
+    async def send_pic(
+        self, ctx, group_str: str, state_str: str, bw: Union[bool, str] = False, retries=0
+    ):
+        if isinstance(bw, str):
+            bw = bw == "bw"
 
         logger.info(
             f"{config.options['id_type'][:-1]}: "
@@ -90,10 +95,23 @@ class Media(commands.Cog):
             session_increment(ctx, "total", 1)
 
             if config.options["id_groups"]:
-                build = build_id_list(group_str)
-                choices = build[0]
+                await ctx.send(
+                    f"**Recognized arguments:** *Black & White*: `{bw}`, "
+                    + f"*{config.options['category_name']}*: `{'None' if group_str == '' else group_str}`"
+                    + f"*Detected State: `{'None' if state_str == '' else state_str}`"
+                )
             else:
-                choices = id_list
+                await ctx.send(f"**Recognized arguments:** *Black & White*: `{bw}`")
+
+            choices = build_id_list(group_str, state_str)
+
+            if not choices:
+                logger.info(f"no {config.options['id_type']} for taxon/state")
+                await ctx.send(
+                    f"**Sorry, no {config.options['id_type']} could be found for the taxon/state combo."
+                    + "**\n*Please try again*"
+                )
+                return
 
             current_item = random.choice(choices)
             self.increment_item_frequency(ctx, current_item)
@@ -121,6 +139,100 @@ class Media(commands.Cog):
                 bw=bw,
             )
 
+    @staticmethod
+    async def parse(ctx, args_str: str):
+        """Parse arguments for options."""
+
+        args = args_str.split(" ")
+        logger.info(f"args: {args}")
+
+        if not database.exists(f"race.data:{ctx.channel.id}"):
+            group_args = set()
+            state_args = set()
+            for arg in set(args):
+                arg = arg.lower()
+                if arg == "bw":
+                    continue
+                if arg in all_categories:
+                    group_args.add(dealias_group(arg))
+                elif arg.upper() in states.keys():
+                    state_args.add(dealias_group(arg))
+                else:
+                    await ctx.send(f"**Invalid argument provided**: `{arg}`")
+                    return
+            group = " ".join(group_args).strip()
+            state = " ".join(state_args).strip()
+
+            if database.exists(f"session.data:{ctx.author.id}"):
+                logger.info("session parameters")
+
+                if group_args:
+                    current_groups = set(
+                        database.hget(f"session.data:{ctx.author.id}", "group")
+                        .decode("utf-8")
+                        .split(" ")
+                    )
+                    logger.info(f"toggle groups: {group_args}")
+                    logger.info(f"current groups: {current_groups}")
+                    group_args.symmetric_difference_update(current_groups)
+                    group_args.discard("")
+                    logger.info(f"new groups: {group_args}")
+                    group = " ".join(group_args).strip()
+                else:
+                    group = database.hget(
+                        f"session.data:{ctx.author.id}", "group"
+                    ).decode("utf-8")
+
+                chosen_state = (
+                    database.hget(f"session.data:{ctx.author.id}", "state")
+                    .decode("utf-8")
+                    .split(" ")
+                )
+                if chosen_state[0] == "":
+                    chosen_state = []
+                if not chosen_state:
+                    logger.info("no session lists")
+                    chosen_state = check_state_role(ctx)
+
+                session_bw = (
+                    database.hget(f"session.data:{ctx.author.id}", "bw").decode("utf-8")
+                    == "bw"
+                )
+                bw = not session_bw if "bw" in args else session_bw
+            else:
+                chosen_state = check_state_role(ctx)
+                bw = "bw" in args
+
+            if state_args:
+                logger.info(f"toggle states: {state_args}")
+                logger.info(f"current states: {chosen_state}")
+                state_args.symmetric_difference_update(set(chosen_state))
+                state_args.discard("")
+                logger.info(f"new states: {state_args}")
+                state = " ".join(state_args).strip()
+            else:
+                state = " ".join(chosen_state).strip()
+
+        else:
+            logger.info("race parameters")
+
+            race_bw = (
+                database.hget(f"race.data:{ctx.channel.id}", "filter").decode("utf-8")
+                == "bw"
+            )
+            bw = not race_bw if "bw" in args else race_bw
+
+            group = database.hget(f"race.data:{ctx.channel.id}", "group").decode(
+                "utf-8"
+            )
+            state = database.hget(f"race.data:{ctx.channel.id}", "state").decode(
+                "utf-8"
+            )
+
+        logger.info(f"args: bw: {bw}; group: {group}; state: {state}")
+
+        return (bw, group, state)
+
     # Pic command - no args
     # help text
     @commands.command(
@@ -129,76 +241,13 @@ class Media(commands.Cog):
     )
     # 5 second cooldown
     @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.channel))
-    async def pic(self, ctx, *args):
+    async def pic(self, ctx, *, args_str: str = ""):
         logger.info("command: pic")
+        logger.info(f"args: {args_str}")
 
-        logger.info(f"args: {args}")
+        bw, group, state = await self.parse(ctx, args_str)
 
-        # parse args
-        bw = False
-        toggle_groups = []
-        for arg in set(args):
-            arg = arg.lower()
-            if arg == "bw":
-                bw = True
-            elif arg in all_categories:
-                toggle_groups.append(dealias_group(arg))
-            else:
-                await ctx.send(f"**Invalid argument provided**: `{arg}`")
-                return
-
-        logger.info(f"group_args: {toggle_groups}")
-        if toggle_groups:
-            group = " ".join(toggle_groups).strip()
-        else:
-            group = ""
-
-        if database.exists(f"session.data:{ctx.author.id}"):
-            logger.info("session parameters")
-            # handle group args
-            if toggle_groups:
-                current_groups = (
-                    database.hget(f"session.data:{ctx.author.id}", "group")
-                    .decode("utf-8")
-                    .split(" ")
-                )
-                add_groups = []
-                logger.info(f"toggle group: {toggle_groups}")
-                logger.info(f"current group: {current_groups}")
-                for o in set(toggle_groups).symmetric_difference(set(current_groups)):
-                    add_groups.append(o)
-                logger.info(f"adding groups: {add_groups}")
-                group = " ".join(add_groups).strip()
-            else:
-                group = database.hget(f"session.data:{ctx.author.id}", "group").decode(
-                    "utf-8"
-                )
-
-            if database.hget(f"session.data:{ctx.author.id}", "bw").decode("utf-8"):
-                bw = not bw
-
-        if database.exists(f"race.data:{ctx.channel.id}"):
-            logger.info("race parameters")
-
-            if database.hget(f"race.data:{ctx.channel.id}", "bw").decode("utf-8"):
-                bw = not bw
-
-        if not config.options["id_groups"]:
-            group = ""
-
-        logger.info(f"args: bw: {bw}; group: {group}")
-        if (
-            int(database.hget(f"channel:{ctx.channel.id}", "answered"))
-            and config.options["id_groups"]
-        ):
-            await ctx.send(
-                f"**Recognized arguments:** *Black & White*: `{bw}`, "
-                + f"*{config.options['category_name']}*: `{'None' if group == '' else group}`"
-            )
-        else:
-            await ctx.send(f"**Recognized arguments:** *Black & White*: `{bw}`")
-
-        await self.send_pic(ctx, group, bw)
+        await self.send_pic(ctx, group, state, bw=bw)
 
 
 def setup(bot):

--- a/sciolyid/cogs/race.py
+++ b/sciolyid/cogs/race.py
@@ -22,7 +22,13 @@ from discord.ext import commands
 from discord.utils import escape_markdown as esc
 
 import sciolyid.config as config
-from sciolyid.data import all_categories, database, dealias_group, logger
+from sciolyid.data import (
+    all_categories,
+    database,
+    dealias_group,
+    logger,
+    states,
+)
 from sciolyid.functions import CustomCooldown, fetch_get_user
 
 
@@ -32,8 +38,8 @@ class Race(commands.Cog):
 
     @staticmethod
     def _get_options(ctx):
-        bw, group, limit, strict = database.hmget(
-            f"race.data:{ctx.channel.id}", ["bw", "group", "limit", "strict"]
+        bw, state, group, limit, strict = database.hmget(
+            f"race.data:{ctx.channel.id}", ["bw", "state", "group", "limit", "strict"]
         )
         options = (
             f"**Black & White:** {bw==b'bw'}\n"
@@ -42,6 +48,7 @@ class Race(commands.Cog):
                 if config.options["id_groups"]
                 else ""
             )
+            + f"**Alternate List:** {state.decode('utf-8') if state else 'None'}\n"
             + f"**Amount to Win:** {limit.decode('utf-8')}\n"
             + f"**Strict Spelling:** {strict == b'strict'}"
         )
@@ -81,7 +88,9 @@ class Race(commands.Cog):
                 else:
                     user_info = f"**{esc(user.name)}#{user.discriminator}**"
             else:
-                user_info = f"**{esc(user.name)}#{user.discriminator}** ({user.mention})"
+                user_info = (
+                    f"**{esc(user.name)}#{user.discriminator}** ({user.mention})"
+                )
 
             leaderboard += f"{i+1}. {user_info} - {int(stats[1])}\n"
 
@@ -153,10 +162,10 @@ class Race(commands.Cog):
         Arguments passed will become the default arguments to '{config.options['prefixes'][0]}pic', but some can be manually overwritten during use.
         Arguments can be passed in any order.""",
         aliases=["st"],
-        usage=f"[bw]{' [group]' if config.options['id_groups'] else ''} [amount to win (default 10)]",
+        usage=f"[bw] [state]{' [group]' if config.options['id_groups'] else ''} [amount to win (default 10)]",
     )
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.channel))
-    async def start(self, ctx, *args):
+    async def start(self, ctx, *, args_str: str = ""):
         logger.info("command: start race")
 
         if not str(ctx.channel.name).startswith("racing"):
@@ -173,52 +182,69 @@ class Race(commands.Cog):
                 f"**There is already a race in session.** *View stats with `{config.options['prefixes'][0]}race view`*"
             )
             return
+
+        args = args_str.split(" ")
         logger.info(f"args: {args}")
 
-        # parse args
+        group_args = set()
+        state_args = set()
         bw = ""
         strict = ""
-        group_args = []
-        limit = 10
+        limit = None
         for arg in set(args):
             arg = arg.lower()
-            if arg == "strict":
-                strict = "strict"
-            elif arg == "bw":
+            if arg == "bw":
                 bw = "bw"
+            elif arg == "strict":
+                strict = "strict"
             elif arg in all_categories:
-                group_args.append(dealias_group(arg))
+                group_args.add(dealias_group(arg))
+            elif arg.upper() in states.keys():
+                state_args.add(dealias_group(arg))
             else:
-                try:
-                    limit = int(arg)
-                except ValueError:
-                    await ctx.send(f"**Invalid argument provided**: `{arg}`")
-                    return
+                if not limit:
+                    try:
+                        limit = int(arg)
+                        continue
+                    except ValueError:
+                        pass
+                await ctx.send(f"**Invalid argument provided**: `{arg}`")
+                return
         group = " ".join(group_args).strip()
+        state = " ".join(state_args).strip()
+        limit = limit if limit else 10
 
         if limit > 1000000:
             await ctx.send("**Sorry, the maximum amount to win is 1 million.**")
             limit = 1000000
 
-        logger.info(f"adding bw: {bw}; group: {group}; ")
+        logger.info(f"bw: {bw}; group: {group}; state: {state}; limit: {limit}")
 
-        database.hmset(
+        database.hset(
             f"race.data:{ctx.channel.id}",
-            {
+            mapping={
                 "start": round(time.time()),
                 "stop": 0,
                 "limit": limit,
+                "state": state,
                 "bw": bw,
                 "group": group,
                 "strict": strict,
             },
         )
-        database.zadd(f"race.scores:{ctx.channel.id}", {str(ctx.author.id): 0})
-        await ctx.send(f"**Race started with options:**\n{self._get_options(ctx)}")
 
-        logger.info("auto sending next image")
+        database.zadd(f"race.scores:{ctx.channel.id}", {str(ctx.author.id): 0})
+        await ctx.send(
+            f"**Race started with options:**\n{self._get_options(ctx)}"
+        )
+
+        logger.info("clearing previous item")
+        database.hset(f"channel:{ctx.channel.id}", "item", "")
+        database.hset(f"channel:{ctx.channel.id}", "answered", "1")
+
+        logger.info("auto sending next item")
         media = self.bot.get_cog("Media")
-        await media.send_pic(ctx, group, bw)
+        await media.send_pic(ctx, group, state, bw)
 
     @race.command(
         brief="- Views race",

--- a/sciolyid/cogs/sessions.py
+++ b/sciolyid/cogs/sessions.py
@@ -22,7 +22,7 @@ from discord.ext import commands
 
 import sciolyid.config as config
 from sciolyid.data import all_categories, database, dealias_group, logger, states
-from sciolyid.functions import CustomCooldown
+from sciolyid.functions import CustomCooldown, check_state_role
 
 
 class Sessions(commands.Cog):
@@ -149,7 +149,6 @@ class Sessions(commands.Cog):
         bw = ""
         strict = ""
         wiki = ""
-        limit = None
         for arg in set(args):
             arg = arg.lower()
             if arg == "bw":
@@ -165,13 +164,18 @@ class Sessions(commands.Cog):
             else:
                 await ctx.send(f"**Invalid argument provided**: `{arg}`")
                 return
-        state = " ".join(state_args).strip()
+
+        if state_args:
+            state = " ".join(state_args).strip()
+        else:
+            state = " ".join(check_state_role(ctx))
+
         if group_args and config.options["id_groups"]:
             group = " ".join(group_args).strip()
         else:
             group = ""
 
-        logger.info(f"adding bw: {bw}; group: {group}; wiki: {wiki}; strict: {strict}")
+        logger.info(f"adding bw: {bw}; group: {group}; state: {state}; wiki: {wiki}; strict: {strict}")
 
         database.hset(
             f"session.data:{ctx.author.id}",
@@ -182,6 +186,7 @@ class Sessions(commands.Cog):
                 "incorrect": 0,
                 "total": 0,
                 "bw": bw,
+                "state": state,
                 "group": group,
                 "wiki": wiki,
                 "strict": strict,

--- a/sciolyid/cogs/sessions.py
+++ b/sciolyid/cogs/sessions.py
@@ -21,7 +21,7 @@ import discord
 from discord.ext import commands
 
 import sciolyid.config as config
-from sciolyid.data import all_categories, database, dealias_group, logger
+from sciolyid.data import all_categories, database, dealias_group, logger, states
 from sciolyid.functions import CustomCooldown
 
 
@@ -31,8 +31,8 @@ class Sessions(commands.Cog):
 
     @staticmethod
     def _get_options(ctx):
-        bw, group, wiki, strict = database.hmget(
-            f"session.data:{ctx.author.id}", ["bw", "group", "wiki", "strict"]
+        bw, state, group, wiki, strict = database.hmget(
+            f"session.data:{ctx.author.id}", ["bw", "state", "group", "wiki", "strict"]
         )
         options = (
             f"**Black & White:** {bw==b'bw'}\n"
@@ -41,6 +41,7 @@ class Sessions(commands.Cog):
                 if config.options["id_groups"]
                 else ""
             )
+            + f"**Alternate List:** {state.decode('utf-8') if state else 'None'}\n"
             + f"**Wiki Embeds**: {wiki==b'wiki'}\n"
             + f"**Strict Spelling**: {strict==b'strict'}"
         )
@@ -108,7 +109,8 @@ class Sessions(commands.Cog):
         help="- Base session command\nSessions will record your activity for an amount of time and "
         + "will give you stats on how your performance and "
         + "also set global variables such as black and white"
-        + (" or specific categories." if config.options["id_groups"] else "."),
+        + (", specific categories, " if config.options["id_groups"] else "")
+        + "or alternate lists.",
         aliases=["ses", "sesh"],
     )
     async def session(self, ctx):
@@ -126,7 +128,7 @@ class Sessions(commands.Cog):
         + f"These settings can be changed at any time with '{config.options['prefixes'][0]}session edit', "
         + "and arguments can be passed in any order.\n",
         aliases=["st"],
-        usage=("[bw] [category]" if config.options["id_groups"] else "[bw]"),
+        usage=(f"[bw] [state]{' [category]' if config.options['id_groups'] else ''}"),
     )
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.user))
     async def start(self, ctx, *args):
@@ -142,10 +144,12 @@ class Sessions(commands.Cog):
         logger.info(f"args: {args}")
 
         # parse args
+        group_args = set()
+        state_args = set()
         bw = ""
-        wiki = ""
         strict = ""
-        group_args = []
+        wiki = ""
+        limit = None
         for arg in set(args):
             arg = arg.lower()
             if arg == "bw":
@@ -155,10 +159,13 @@ class Sessions(commands.Cog):
             elif arg == "strict":
                 strict = "strict"
             elif arg in all_categories:
-                group_args.append(dealias_group(arg))
+                group_args.add(dealias_group(arg))
+            elif arg.upper() in states.keys():
+                state_args.add(dealias_group(arg))
             else:
                 await ctx.send(f"**Invalid argument provided**: `{arg}`")
                 return
+        state = " ".join(state_args).strip()
         if group_args and config.options["id_groups"]:
             group = " ".join(group_args).strip()
         else:
@@ -166,9 +173,9 @@ class Sessions(commands.Cog):
 
         logger.info(f"adding bw: {bw}; group: {group}; wiki: {wiki}; strict: {strict}")
 
-        database.hmset(
+        database.hset(
             f"session.data:{ctx.author.id}",
-            {
+            mapping={
                 "start": round(time.time()),
                 "stop": 0,
                 "correct": 0,
@@ -188,72 +195,94 @@ class Sessions(commands.Cog):
         help="- Views session\nSessions will record your activity for an amount of time and "
         + "will give you stats on how your performance and "
         + "also set global variables such as black and white"
-        + (" or specific categories." if config.options["id_groups"] else "."),
+        + (", specific categories, " if config.options["id_groups"] else "")
+        + "or alternate lists.",
         aliases=["view"],
-        usage=("[bw] [category]" if config.options["id_groups"] else "[bw]"),
+        usage=(f"[bw] [state]{' [category]' if config.options['id_groups'] else ''}"),
     )
     @commands.check(CustomCooldown(3.0, bucket=commands.BucketType.user))
     async def edit(self, ctx, *args):
         logger.info("command: view session")
 
-        if database.exists(f"session.data:{ctx.author.id}"):
-            logger.info(f"args: {args}")
-
-            # parse args
-            group_args = []
-            for arg in set(args):
-                arg = arg.lower()
-                if arg == "bw":
-                    if not database.hget(f"session.data:{ctx.author.id}", "bw"):
-                        logger.info("adding bw")
-                        database.hset(f"session.data:{ctx.author.id}", "bw", "bw")
-                    else:
-                        logger.info("removing bw")
-                        database.hset(f"session.data:{ctx.author.id}", "bw", "")
-                elif arg == "wiki":
-                    if database.hget(f"session.data:{ctx.author.id}", "wiki"):
-                        logger.info("disabling wiki embeds")
-                        database.hset(f"session.data:{ctx.author.id}", "wiki", "")
-                    else:
-                        logger.info("enabling wiki embeds")
-                        database.hset(f"session.data:{ctx.author.id}", "wiki", "wiki")
-                elif arg == "strict":
-                    if database.hget(f"session.data:{ctx.author.id}", "strict"):
-                        logger.info("disabling strict spelling")
-                        database.hset(f"session.data:{ctx.author.id}", "strict", "")
-                    else:
-                        logger.info("enabling strict spelling")
-                        database.hset(
-                            f"session.data:{ctx.author.id}", "strict", "strict"
-                        )
-                elif arg in all_categories:
-                    group_args.append(dealias_group(arg))
-                else:
-                    await ctx.send(f"**Invalid argument provided**: `{arg}`")
-                    return
-            if group_args and config.options["id_groups"]:
-                toggle_group = list(group_args)
-                current_group = (
-                    database.hget(f"session.data:{ctx.author.id}", "group")
-                    .decode("utf-8")
-                    .split(" ")
-                )
-                add_group = []
-                logger.info(f"toggle group: {toggle_group}")
-                logger.info(f"current group: {current_group}")
-                for o in set(toggle_group).symmetric_difference(set(current_group)):
-                    add_group.append(o)
-                logger.info(f"adding groups: {add_group}")
-                database.hset(
-                    f"session.data:{ctx.author.id}",
-                    "group",
-                    " ".join(add_group).strip(),
-                )
-            await self._send_stats(ctx, "**Session started previously.**\n")
-        else:
+        if not database.exists(f"session.data:{ctx.author.id}"):
             await ctx.send(
                 f"**There is no session running.** *You can start one with `{config.options['prefixes'][0]}session start`*"
             )
+            return
+
+        logger.info(f"args: {args}")
+
+        # parse args
+        group_args = set()
+        state_args = set()
+        for arg in set(args):
+            arg = arg.lower()
+            if arg == "bw":
+                if not database.hget(f"session.data:{ctx.author.id}", "bw"):
+                    logger.info("adding bw")
+                    database.hset(f"session.data:{ctx.author.id}", "bw", "bw")
+                else:
+                    logger.info("removing bw")
+                    database.hset(f"session.data:{ctx.author.id}", "bw", "")
+            elif arg == "wiki":
+                if database.hget(f"session.data:{ctx.author.id}", "wiki"):
+                    logger.info("disabling wiki embeds")
+                    database.hset(f"session.data:{ctx.author.id}", "wiki", "")
+                else:
+                    logger.info("enabling wiki embeds")
+                    database.hset(f"session.data:{ctx.author.id}", "wiki", "wiki")
+            elif arg == "strict":
+                if database.hget(f"session.data:{ctx.author.id}", "strict"):
+                    logger.info("disabling strict spelling")
+                    database.hset(f"session.data:{ctx.author.id}", "strict", "")
+                else:
+                    logger.info("enabling strict spelling")
+                    database.hset(
+                        f"session.data:{ctx.author.id}", "strict", "strict"
+                    )
+            elif arg in all_categories:
+                group_args.add(dealias_group(arg))
+            elif arg.upper() in states.keys():
+                state_args.add(dealias_group(arg))
+            else:
+                await ctx.send(f"**Invalid argument provided**: `{arg}`")
+                return
+
+        if state_args:
+            current_states = set(
+                database.hget(f"session.data:{ctx.author.id}", "state")
+                .decode("utf-8")
+                .split(" ")
+            )
+            logger.info(f"toggle states: {state_args}")
+            logger.info(f"current states: {current_states}")
+            state_args.symmetric_difference_update(current_states)
+            state_args.discard("")
+            logger.info(f"new states: {state_args}")
+            database.hset(
+                f"session.data:{ctx.author.id}",
+                "state",
+                " ".join(state_args).strip(),
+            )
+
+        if group_args and config.options["id_groups"]:
+            current_group = set(
+                database.hget(f"session.data:{ctx.author.id}", "group")
+                .decode("utf-8")
+                .split(" ")
+            )
+            logger.info(f"toggle group: {group_args}")
+            logger.info(f"current group: {current_group}")
+            group_args.symmetric_difference_update(current_group)
+            group_args.discard("")
+            logger.info(f"new groups: {group_args}")
+            database.hset(
+                f"session.data:{ctx.author.id}",
+                "group",
+                " ".join(group_args).strip(),
+            )
+        await self._send_stats(ctx, "**Session started previously.**\n")
+
 
     # stops session
     @session.command(help="- Stops session", aliases=["stp", "end"])

--- a/sciolyid/cogs/skip.py
+++ b/sciolyid/cogs/skip.py
@@ -56,11 +56,11 @@ class Skip(commands.Cog):
                     await race.stop_race(ctx)
                 else:
                     logger.info("auto sending next image")
-                    group, bw = database.hmget(
-                        f"race.data:{ctx.channel.id}", ["group", "bw"]
+                    group, state, bw = database.hmget(
+                        f"race.data:{ctx.channel.id}", ["group", "state", "bw"]
                     )
                     media = self.bot.get_cog("Media")
-                    await media.send_pic(ctx, group.decode("utf-8"), bw.decode("utf-8"))
+                    await media.send_pic(ctx, group.decode("utf-8"), state.decode("utf-8"), bw.decode("utf-8"))
         else:
             await ctx.send("You need to ask for an image first!")
 

--- a/sciolyid/cogs/state.py
+++ b/sciolyid/cogs/state.py
@@ -1,0 +1,190 @@
+# state.py | commands for alternate lists
+# Copyright (C) 2019-2021  EraserBird, person_v1.32
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import string
+
+import discord
+from discord.ext import commands
+from sentry_sdk import capture_exception
+
+import sciolyid.config as config
+from sciolyid.data import GenericError, database, logger, states
+from sciolyid.functions import CustomCooldown
+
+
+class States(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    async def broken_send(self, ctx, message, between=""):
+        pages = []
+        temp_out = ""
+        for line in message.splitlines(keepends=True):
+            temp_out += line
+            if len(temp_out) > 1700:
+                temp_out = f"{between}{temp_out}{between}"
+                pages.append(temp_out.strip())
+                temp_out = ""
+        temp_out = f"{between}{temp_out}{between}"
+        if temp_out.strip():
+            pages.append(temp_out.strip())
+        for item in pages:
+            await ctx.send(item)
+
+    # set state role
+    @commands.command(
+        help=f"- Sets an alternate {config.options['id_type']} list",
+        name="set",
+        aliases=["state", "alt"],
+    )
+    @commands.check(CustomCooldown(5.0, bucket=commands.BucketType.user))
+    @commands.guild_only()
+    @commands.bot_has_permissions(manage_roles=True)
+    async def state(self, ctx, *, args):
+        logger.info("command: state set")
+
+        raw_roles = ctx.author.roles
+        role_ids = [role.id for role in raw_roles]
+        role_names = [role.name.lower() for role in ctx.author.roles]
+        args = args.upper().split(" ")
+
+        added = []
+        removed = []
+        invalid = []
+        for arg in args:
+            if arg not in states:
+                logger.info("invalid state")
+                invalid.append(arg)
+
+            # gets similarities
+            elif not set(role_names).intersection(set(states[arg]["aliases"])):
+                # need to add role (does not have role)
+                logger.info("add roles")
+                raw_roles = ctx.guild.roles
+                guild_role_names = [role.name.lower() for role in raw_roles]
+                guild_role_ids = [role.id for role in raw_roles]
+
+                if states[arg]["aliases"][0].lower() in guild_role_names:
+                    # guild has role
+                    index = guild_role_names.index(states[arg]["aliases"][0].lower())
+                    role = ctx.guild.get_role(guild_role_ids[index])
+
+                else:
+                    # create role
+                    logger.info("creating role")
+                    role = await ctx.guild.create_role(
+                        name=string.capwords(states[arg]["aliases"][0]),
+                        permissions=discord.Permissions.none(),
+                        hoist=False,
+                        mentionable=False,
+                        reason=f"Create role for alternate {config.options['id_type']} list",
+                    )
+
+                await ctx.author.add_roles(
+                    role,
+                    reason=f"Set role for alternate {config.options['id_type']} list",
+                )
+                added.append(role.name)
+
+            else:
+                # have roles already (there were similarities)
+                logger.info("already has role, removing")
+                index = role_names.index(states[arg]["aliases"][0].lower())
+                role = ctx.guild.get_role(role_ids[index])
+                await ctx.author.remove_roles(
+                    role,
+                    reason=f"Remove role for alternate {config.options['id_type']} list",
+                )
+                removed.append(role.name)
+
+        await ctx.send(
+            (
+                f"**Sorry,** `{'`, `'.join(invalid)}` **{'are' if len(invalid) > 1 else 'is'} not a valid list.**\n"
+                + f"*Valid Lists:* `{'`, `'.join(states.keys())}`\n"
+                if invalid
+                else ""
+            )
+            + (
+                f"**Added the** `{'`, `'.join(added)}` **role{'s' if len(added) > 1 else ''}**\n"
+                if added
+                else ""
+            )
+            + (
+                f"**Removed the** `{'`, `'.join(removed)}` **role{'s' if len(removed) > 1 else ''}**\n"
+                if removed
+                else ""
+            )
+        )
+
+    @state.error
+    async def set_error(self, ctx, error):
+        logger.info("state set error")
+        if isinstance(error, commands.MissingRequiredArgument):
+            await ctx.send(
+                f"**Please enter an alternate list.**\n*Valid Lists:* `{'`, `'.join(states.keys())}`"
+            )
+        elif isinstance(error, commands.CommandOnCooldown):  # send cooldown
+            await ctx.send(
+                f"**Cooldown.** Try again after {str(round(error.retry_after))}s.",
+                delete_after=5.0,
+            )
+        elif isinstance(error, commands.NoPrivateMessage):
+            await ctx.send("**This command is unavailable in DMs!**")
+        elif isinstance(error, commands.BotMissingPermissions):
+            await ctx.send(
+                "**The bot does not have enough permissions to fully function.**\n"
+                + f"**Permissions Missing:** `{', '.join(map(str, error.missing_perms))}`\n"
+                + "*Please try again once the correct permissions are set.*"
+            )
+        elif isinstance(error, GenericError):
+            if error.code == 192:
+                # channel is ignored
+                return
+            if error.code == 842:
+                await ctx.send("**Sorry, you cannot use this command.**")
+            elif error.code == 666:
+                logger.info("GenericError 666")
+            elif error.code == 201:
+                logger.info("HTTP Error")
+                capture_exception(error)
+                await ctx.send(
+                    "**An unexpected HTTP Error has occurred.**\n *Please try again.*"
+                )
+            else:
+                logger.info("uncaught generic error")
+                capture_exception(error)
+                await ctx.send(
+                    "**An uncaught generic error has occurred.**\n"
+                    + "*Please log this message in #support in the support server below, or try again.*\n"
+                    + "**Error:** "
+                    + str(error)
+                )
+                await ctx.send("https://discord.gg/fXxYyDJ")
+                raise error
+        else:
+            capture_exception(error)
+            await ctx.send(
+                "**An uncaught set error has occurred.**\n"
+                + "*Please log this message in #support in the support server below, or try again.*\n"
+                + "**Error:** "
+                + str(error)
+            )
+            await ctx.send("https://discord.gg/fXxYyDJ")
+            raise error
+
+
+def setup(bot):
+    bot.add_cog(States(bot))

--- a/sciolyid/config.py
+++ b/sciolyid/config.py
@@ -43,6 +43,7 @@ optional: Dict[str, Any] = {
     "download_dir": "github_download/",  # local directory containing media (images)
     "data_dir": "data/",  # local directory containing the id data
     "list_dir": "lists/",  # directory within data_dir containing id lists
+    "state_dir": "state/",  # directory within data_dir containing alternate lists, False/None to disable
     "restricted_list_dir": None,  # directory within data_dir containg id lists that are available by selection only
     "wikipedia_file": "wikipedia.txt",  # filename within data_dir containing wiki urls for every item
     "meme_file": None,

--- a/sciolyid/config.py
+++ b/sciolyid/config.py
@@ -42,9 +42,9 @@ optional: Dict[str, Any] = {
     "download_func": None,  # asyncronous function that downloads images locally to download_dir
     "download_dir": "github_download/",  # local directory containing media (images)
     "data_dir": "data/",  # local directory containing the id data
-    "list_dir": "lists/",  # directory within data_dir containing id lists
-    "state_dir": "state/",  # directory within data_dir containing alternate lists, False/None to disable
-    "restricted_list_dir": None,  # directory within data_dir containg id lists that are available by selection only
+    "group_dir": "group/",  # directory within data_dir containing group lists
+    "state_dir": "state/",  # directory within data_dir containing alternate lists
+    "default_state_list": "NATS",  # name of the "state" that should be considered default
     "wikipedia_file": "wikipedia.txt",  # filename within data_dir containing wiki urls for every item
     "meme_file": None,
     "logs": True,  # enable logging

--- a/sciolyid/data.py
+++ b/sciolyid/data.py
@@ -78,6 +78,7 @@ if config.options["sentry"]:
 #                    "correct": 0,
 #                    "incorrect": 0,
 #                    "total": 0,
+#                    "state": state,
 #                    "bw": bw, - Toggles if "bw", doesn't if empty (""), default ""
 #                    "group": group,
 #                    "wiki": wiki, - Enables if "wiki", disables if empty (""), default "wiki"
@@ -89,6 +90,7 @@ if config.options["sentry"]:
 #                    "start": 0
 #                    "stop": 0,
 #                    "limit": 10,
+#                    "state": state,
 #                    "bw": bw,
 #                    "group": group,
 #                    "strict": strict - Enables strict spelling if "strict", disables if empty, default ""
@@ -111,8 +113,8 @@ if config.options["sentry"]:
 #    incorrect.user:user_id: : [item name, # incorrect]
 # }
 
-# correct birds format = {
-#    correct.user:user_id : [bird name, # correct]
+# correct item format = {
+#    correct.user:user_id : [item name, # correct]
 # }
 
 # item frequency format = {
@@ -141,6 +143,17 @@ if config.options["sentry"]:
 
 # leave confirm format:
 #   leave:guild_id : 0
+
+#  states = {
+#          state name:
+#               {
+#               aliases: [alias1, alias2...],
+#               list: [item1, item2...],
+#               }
+#          }
+
+# state items are picked from [state_dir]/[state]/list.txt
+# either list can be in any taxon
 
 
 # setup logging
@@ -292,6 +305,30 @@ def _groups():
 
     logger.info("Done with lists!")
     return (lists, aliases_)
+
+
+def _state_lists():
+    """Converts txt files of state data into lists."""
+    filenames = ("list", "aliases")
+    states_ = {}
+    state_names = os.listdir(config.options['state_dir'])
+    for state in state_names:
+        states_[state] = {}
+        logger.info(f"Working on {state}")
+        for filename in filenames:
+            logger.info(f"Working on {filename}")
+            with open(f"{config.options['state_dir']}/{state}/{filename}.txt", "r") as f:
+                states_[state][filename] = [
+                    line.strip().lower()
+                    if filename != "aliases"
+                    else line.strip()
+                    for line in f
+                    if line != "EMPTY"
+                ]
+            logger.info(f"Done with {filename}")
+        logger.info(f"Done with {state}")
+    logger.info("Done with states list!")
+    return states_
 
 
 def _memes():

--- a/sciolyid/data.py
+++ b/sciolyid/data.py
@@ -281,18 +281,12 @@ def dealias_group(group):
 
 def _groups():
     """Converts txt files of data into lists."""
-    filenames = [(f"{config.options['list_dir']}{name}", name.split(".")[0]) for name in os.listdir(config.options["list_dir"])]
-    restricted_filenames = []
-    if config.options["restricted_list_dir"]:
-        restricted_filenames = [
-            (f"{config.options['restricted_list_dir']}{name}", name.split(".")[0])
-            for name in os.listdir(config.options["restricted_list_dir"])
-        ]
+    filenames = [(f"{config.options['group_dir']}{name}", name.split(".")[0]) for name in os.listdir(config.options["group_dir"])]
 
     # Converts txt file of data into lists
     lists = {}
     aliases_ = {}
-    for filename, category_name in filenames + restricted_filenames:
+    for filename, category_name in filenames:
         logger.info(f"Working on {filename}")
         lists[category_name] = []
         with open(filename, "r") as f:
@@ -344,25 +338,13 @@ def _memes():
 
 def _all_lists():
     """Compiles lists into master lists."""
-    id_list_ = []
-    master_id_list_ = []
-    restricted = []
-    if config.options["restricted_list_dir"]:
-        restricted = [
-            name.split(".")[0]
-            for name in os.listdir(config.options["restricted_list_dir"])
-        ]
-    for group in groups:
-        if group in restricted:
-            for item in groups[group]:
-                master_id_list_.append(item)
-        else:
-            for item in groups[group]:
-                id_list_.append(item)
-                master_id_list_.append(item)
-    id_list_ = list(set(id_list_))
-    master_id_list_ = list(set(master_id_list_))
-    return id_list_, master_id_list_
+    logger.info("Working on master lists")
+    master = []
+    for state in states.values():
+        master += state["list"]
+    master = list(set(master))
+    logger.info("Done with master lists!")
+    return master
 
 
 def _config():
@@ -381,9 +363,11 @@ def _config():
 
 
 groups, aliases = _groups()
+states = _state_lists()
 meme_list = _memes()
-id_list, master_id_list = _all_lists()
+master_id_list = _all_lists()
 wikipedia_urls = _wiki_urls()
+id_list = states[config.options["default_state_list"]]
 _config()
 
 all_categories = set(

--- a/sciolyid/data.py
+++ b/sciolyid/data.py
@@ -270,6 +270,8 @@ def get_category(item: str):
 
 def dealias_group(group):
     """Resolve group to a real category by expanding aliases."""
+    if group not in all_categories:
+        return None
     if group in groups.keys():
         return group
     return next(

--- a/sciolyid/data.py
+++ b/sciolyid/data.py
@@ -281,7 +281,10 @@ def dealias_group(group):
 
 def _groups():
     """Converts txt files of data into lists."""
-    filenames = [(f"{config.options['group_dir']}{name}", name.split(".")[0]) for name in os.listdir(config.options["group_dir"])]
+    filenames = [
+        (f"{config.options['group_dir']}{name}", name.lower().split(".")[0])
+        for name in os.listdir(config.options["group_dir"])
+    ]
 
     # Converts txt file of data into lists
     lists = {}
@@ -305,17 +308,17 @@ def _state_lists():
     """Converts txt files of state data into lists."""
     filenames = ("list", "aliases")
     states_ = {}
-    state_names = os.listdir(config.options['state_dir'])
+    state_names = os.listdir(config.options["state_dir"])
     for state in state_names:
-        states_[state] = {}
+        states_[state.upper()] = {}
         logger.info(f"Working on {state}")
         for filename in filenames:
             logger.info(f"Working on {filename}")
-            with open(f"{config.options['state_dir']}/{state}/{filename}.txt", "r") as f:
-                states_[state][filename] = [
-                    line.strip().lower()
-                    if filename != "aliases"
-                    else line.strip()
+            with open(
+                f"{config.options['state_dir']}/{state}/{filename}.txt", "r"
+            ) as f:
+                states_[state.upper()][filename] = [
+                    line.strip().lower() if filename != "aliases" else line.strip()
                     for line in f
                     if line != "EMPTY"
                 ]

--- a/sciolyid/functions.py
+++ b/sciolyid/functions.py
@@ -96,9 +96,9 @@ async def channel_setup(ctx):
     """
     logger.info("checking channel setup")
     if not database.exists(f"channel:{ctx.channel.id}"):
-        database.hmset(
+        database.hset(
             f"channel:{ctx.channel.id}",
-            {"item": "", "answered": 1, "prevJ": 20, "prevI": ""},
+            mapping={"item": "", "answered": 1, "prevJ": 20, "prevI": ""},
         )
         # true = 1, false = 0, prevJ is 20 to define as integer
         logger.info("channel data added")

--- a/sciolyid/start_bot.py
+++ b/sciolyid/start_bot.py
@@ -88,6 +88,7 @@ initial_extensions = [
     "sciolyid.cogs.hint",
     "sciolyid.cogs.score",
     "sciolyid.cogs.stats",
+    "sciolyid.cogs.state",
     "sciolyid.cogs.sessions",
     "sciolyid.cogs.race",
     "sciolyid.cogs.meta",


### PR DESCRIPTION
This PR adds states, also known as alternate lists. This allows alternative lists to be available to use, similar to how Bird-ID has different lists for different states. The "restricted taxon", which was originally implemented to get around not having state lists, is now removed.

The data file structure is slightly different as a result - lists are specified in a folder and a default list is set in the config. Taxons are supplementary only to allow selecting only specimens in both the selected list and taxon.